### PR TITLE
feat(GreatestBatteryPowerUsedFirst):battery used at the switch has th…

### DIFF
--- a/Assets/Scripts/Inventory.cs
+++ b/Assets/Scripts/Inventory.cs
@@ -4,11 +4,11 @@ using UnityEngine;
 
 public class Inventory : MonoBehaviour {
 
-    private ArrayList items;
+	private List<GameObject> items;
 
 	// Use this for initialization
 	void Start () {
-		items = new ArrayList ();
+		items = new List<GameObject> ();
 	}
 	
 	// Update is called once per frame
@@ -54,9 +54,13 @@ public class Inventory : MonoBehaviour {
     //test method for test scene 1 ONLY
     public GameObject getFirstItem()
     {
+		sortDescending ();
         GameObject gameObj = (GameObject)(items[0]);
         removeItem(gameObj);
         return gameObj;
     }
 
+	public void sortDescending(){
+		items.Sort ((x, y) => y.GetComponent<Battery>().getPowerIndex().CompareTo(x.GetComponent<Battery>().getPowerIndex()));
+	}
 }


### PR DESCRIPTION
…e greatest amount of power

The game play currently selects the first battery item in the inventory to place on the switch, but since dead batteries can be collected, there needs to be a way where the batteries that are not dead are used first. The solution to this is to sort the inventory items in descending power order so that the player doesn't use a dead battery to power a switch when there are other functioning batteries in the player's inventory.