### PR TITLE
feat(StopSanityDecrement):player has battery, sanity stops decreasing

### DIFF
--- a/Assets/Plugins.meta
+++ b/Assets/Plugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2aee7617db83d51498429ec04577bb6c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PlayerCharacter.cs
+++ b/Assets/Scripts/PlayerCharacter.cs
@@ -40,7 +40,7 @@ public class PlayerCharacter : MonoBehaviour {
             endGame();
         }
 
-		if (losingSanity && !inElevator) {
+		if (losingSanity && !inElevator && inventory.itemCount() == 0) {
 			sanity -= SANITY_DECREASE_RATE;
 		} else if (inElevator)
         {


### PR DESCRIPTION
When the player has at least 1 battery in his/her possession, and those batteries have power then the player's sanity stops decreasing.