### PR TITLE
feat(colorHaze): sanity < 10, player's view becomes red

### DIFF
--- a/Assets/Scenes/TestScene1.unity
+++ b/Assets/Scenes/TestScene1.unity
@@ -1474,6 +1474,7 @@ RectTransform:
   m_Children:
   - {fileID: 567755404}
   - {fileID: 1094309263}
+  - {fileID: 2133285392}
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3052,6 +3053,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   player: {fileID: 1248575531}
   camera_light: {fileID: 1134062038}
+  colorHaze: {fileID: 2133285391}
 --- !u!4 &1310362849 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4160669633995410, guid: b1e004e2f60ec6840abefcca889b9df2,
@@ -5297,6 +5299,75 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2092334381}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &2133285391
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2133285392}
+  - component: {fileID: 2133285394}
+  - component: {fileID: 2133285393}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &2133285392
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2133285391}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 621889719}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2133285393
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2133285391}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.9811321, g: 0.032395888, b: 0.032395888, a: 0.392}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &2133285394
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2133285391}
+  m_CullTransparentMesh: 0
 --- !u!1 &2134289595
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/LowSanityEffects.cs
+++ b/Assets/Scripts/LowSanityEffects.cs
@@ -7,6 +7,7 @@ public class LowSanityEffects : MonoBehaviour {
     [SerializeField] private GameObject player;
 
     [SerializeField] private Light camera_light;
+	[SerializeField] private GameObject colorHaze;
 
     private float sanity;
 
@@ -28,9 +29,12 @@ public class LowSanityEffects : MonoBehaviour {
             changeSightIntensity(-(Time.deltaTime));
             changeSightAngle(-(Time.deltaTime));
         }
-        if(sanity < 20f) {
-            changeSightColor(Color.red);
-        }
+		if (sanity < 10f) {
+			colorHaze.SetActive (true);
+			//changeSightColor(Color.red);
+		} else {
+			colorHaze.SetActive (false);
+		}
     }
 
     //camera shaking when sanity is lower than 70
@@ -69,6 +73,7 @@ public class LowSanityEffects : MonoBehaviour {
         //see if changing the color gradually would work.
         //Color.Lerp wouldn't work.
         camera_light.color = color;
+
     }
 
     //player will be able to solve a level easier if his sanity level is high


### PR DESCRIPTION
When the sanity's level is less than 10, the player's vision turns red (grayscale -> red tint)