### PR TITLE
fix(cubeSpawningSelection): prevent cubes from spawning in the wrong …

### DIFF
--- a/Assets/Scenes/TestScene1.unity
+++ b/Assets/Scenes/TestScene1.unity
@@ -124,7 +124,7 @@ GameObject:
   - component: {fileID: 35321177}
   - component: {fileID: 35321176}
   - component: {fileID: 35321175}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Zone3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -610,7 +610,7 @@ GameObject:
   - component: {fileID: 207688736}
   - component: {fileID: 207688735}
   - component: {fileID: 207688734}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: DoorZone1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4411,7 +4411,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1620736275}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Elevator
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5036,7 +5036,7 @@ GameObject:
   - component: {fileID: 1862369274}
   - component: {fileID: 1862369273}
   - component: {fileID: 1862369272}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Zone1&2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5215,7 +5215,7 @@ GameObject:
   - component: {fileID: 1872166759}
   - component: {fileID: 1872166758}
   - component: {fileID: 1872166757}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: Switch2
   m_TagString: Switch
   m_Icon: {fileID: 0}
@@ -5554,7 +5554,7 @@ GameObject:
   - component: {fileID: 2046146020}
   - component: {fileID: 2046146023}
   - component: {fileID: 2046146019}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: Switch1
   m_TagString: Switch
   m_Icon: {fileID: 0}

--- a/Assets/Scripts/LowSanityEffects.cs
+++ b/Assets/Scripts/LowSanityEffects.cs
@@ -96,19 +96,26 @@ public class LowSanityEffects : MonoBehaviour {
     public void generateRandomCubes(int number) {
         for (int i = 0; i < number; i++)
         {
-            GameObject cube = Instantiate(cube_prefab) as GameObject;
-            current_cubes.Add(cube);
-            cube.transform.parent = level_one.transform;
             //x ranges from -24 to 24 in Zone 1 and 2 (excluding elevator and Zone 3)
             float x = Random.Range(-24f, 24f);
             //-1f ensures the cube was invisible when instantiated
             float y = -1f;
             //z ranges from 24 to -24
             float z = Random.Range(-24f, 24f);
-            cube.transform.position = new Vector3(x, y, z);
-            cube.transform.eulerAngles = new Vector3(0f, Random.Range(0f, 360f), 0f);
-            //make the cube emerge from the ground
-            StartCoroutine(cubeTransform(cube, new Vector3(x, y + 3f, z), 1f));
+			Vector3 proposedCubePosition = new Vector3(x, y, z);
+			float sphereRadius = 2f;
+			int layerMask = ~(1 << 9);
+			// check to see that there is no other object that collides with the where the cube will be placed
+			if (!Physics.CheckSphere(proposedCubePosition, sphereRadius, layerMask)) {
+				// create cube
+				GameObject cube = Instantiate(cube_prefab) as GameObject;
+				current_cubes.Add(cube);
+				cube.transform.parent = level_one.transform;
+				cube.transform.position = proposedCubePosition;
+				cube.transform.eulerAngles = new Vector3(0f, Random.Range(0f, 360f), 0f);
+				//make the cube emerge from the ground
+				StartCoroutine (cubeTransform (cube, new Vector3 (x, y + 3f, z), 1f));
+			}
         }
     }
 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -19,8 +19,8 @@ TagManager:
   - 
   - 
   - PostProcessing
-  - 
-  - 
+  - WallsFloor
+  - WallItems
   - 
   - 
   - 


### PR DESCRIPTION
…location

Before the sanity effect cubes could spawn in a position where the player is unable to reach the switch or block a door. The fix does not allow these cubes to be spawned near these interactables