### PR TITLE
fix(SecondSwitchMissingDoorRef):battery does not open door

### DIFF
--- a/Assets/Scenes/TestScene1.unity
+++ b/Assets/Scenes/TestScene1.unity
@@ -8060,7 +8060,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7051e5321dd87eb4ab18f837f189a8c8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  door: {fileID: 0}
+  door: {fileID: 1222385081}
   xOffset: 0
   yOffset: 0
   zOffset: -0.3


### PR DESCRIPTION
The switch in Zone 2 does not open when a battery is placed on it. It is missing the door game object reference which I fixed.