### PR TITLE
makes it so the battery can be removed from objects with E

### DIFF
--- a/Assets/Scripts/Battery.cs
+++ b/Assets/Scripts/Battery.cs
@@ -12,6 +12,7 @@ public class Battery : MonoBehaviour {
 	// Use this for initialization
 	void Start () {
 		powerSource = new PowerSource (max_power, power_index);
+		powerSource.theBattery = this; // temporary bad code fix later
 	}
 
 	// Update is called once per frame

--- a/Assets/Scripts/PlayerCharacter.cs
+++ b/Assets/Scripts/PlayerCharacter.cs
@@ -233,13 +233,37 @@ public class PlayerCharacter : MonoBehaviour {
 					} else if (pc.isPowerSourceExtractable())
 					{
 						PowerSource oldPC = pc.removePowerSource();
-						GameObject battery = (GameObject)GameObject.Instantiate(Resources.Load("Battery"));
+						Battery battery = oldPC.theBattery;
+
+						inventory.addItem(battery.gameObject); 
+						battery.gameObject.SetActive(false);
+
+						/*GameObject battery = (GameObject)GameObject.Instantiate(Resources.Load("Prefabs/battery 1"));
 						battery.GetComponent<Battery>().max_power = (int) oldPC.getMaxPower();
 						battery.GetComponent<Battery>().power_index = (int) oldPC.getPowerLevel();
 						battery.GetComponent<Battery>().setPowerSource(new PowerSource(oldPC.getMaxPower(), oldPC.getPowerLevel()));
 						this.inventory.addItem(battery);
-						battery.SetActive(false);
+						battery.SetActive(false);*/
 					}
+
+
+
+					/*Battery battery = other.gameObject.GetComponent<Battery> ();
+					if (battery.deviceBatteryIsAttachedTo != null) {
+						battery.deviceBatteryIsAttachedTo.removePowerSource ();
+						battery.deviceBatteryIsAttachedTo = null;
+						Debug.Log ("Player took battery too early");
+					}*/
+
+
+
+
+
+
+
+
+
+
 				}
 			}
 			// If our RayCast did not hit any objects, then we're not looking at anything, so stop siphoning / giving Power to things.
@@ -280,7 +304,7 @@ public class PlayerCharacter : MonoBehaviour {
 					battery.deviceBatteryIsAttachedTo = null;
 					Debug.Log ("Player took battery too early");
 				}
-				inventory.addItem(other.gameObject); // changed from a bool
+				inventory.addItem(other.gameObject); 
 				other.gameObject.SetActive(false);
 
 			} 

--- a/Assets/Scripts/PowerSource.cs
+++ b/Assets/Scripts/PowerSource.cs
@@ -7,6 +7,8 @@ public class PowerSource {
 	private float maxPower;
 	private float startingPower;
 	private float currentPower;
+	public Battery theBattery; // temporary fix bad code
+
 
 	public PowerSource(float maxPower, float startingPower)
 	{
@@ -95,6 +97,7 @@ public class PowerSource {
 	{
 		return currentPower == maxPower;
 	}
+
 
 	/// <summary>
 	/// Static class method for transferring Power between two arbitrary PowerSources.


### PR DESCRIPTION
Makes it so you can remove batteries from objects with E from switches or other powered devices like the light sources

Known issues
* When you hover over objects the UI needs to be updated to demonstrate that you can do this with charged items
* You still lose your battery if you try to power the computer with it
* It does not work with the charging station, but we're planning on removing it so it's ok